### PR TITLE
Make benchmark more fair towards CPU

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-nvcc main.cu -I$EIGEN_INCLUDE_DIR --expt-relaxed-constexpr
+nvcc main.cu -I$EIGEN_INCLUDE_DIR --expt-relaxed-constexpr -O3 -Xcompiler -march=native -Xcompiler -fopenmp 

--- a/main.cu
+++ b/main.cu
@@ -156,6 +156,7 @@ int main(int argc, char *argv[]) {
     cudaFree(d_ress);
   } else {
     // Run on host
+    #pragma omp parallel for
     for (int it = 0; it < nTracks; it++) {
       propagator.propagate(pars[it], propOptions, ress[it]);
     }


### PR DESCRIPTION
It pains me to say so, but I believe that you accidentally committed the sin of NVidia-style performance benchmarking upon measuring the results that you presented the other day:

- As far as I can see, compiler performance optimizations were not enabled for the CPU code at the time where you benchmarked it.
- The original benchmark was also pitting a single CPU core against a full GPU, which I consider unduly unfair from a performance-per-dollar point of view. I fixed that with a quick OpenMP loop.

After fixing these two problems, the performance picture that I observe is quite a bit different from the one that you presented the other day:

![ResultsPlot](https://user-images.githubusercontent.com/1305080/78060483-de924e00-738b-11ea-9616-c8d2ccca4da3.png)

[Here are the full benchmark details, including hardware configuration, library versions, and launch configuration.](https://github.com/XiaocongAi/gpuKalmanFitter/files/4410806/ResultDetails.log)
