### PR TITLE
Add performance logging to csv output file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ include(cmake/FindEigen.cmake)
 
 # make sure libActscore.so is available at runtime
 #set(CMAKE_INSTALL_RPATH "$ORIGIN/../bin")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -std=c++14 -lineinfo -res-usage -arch=sm_70 -Xcompiler -fopenmp")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -std=c++14 -lineinfo -res-usage -arch=sm_70 -Xcompiler -fopenmp") 
 
 
 add_library(Actscore STATIC ${LIB_SRC_MAT} ${LIB_SRC_SUR} ${LIB_SRC_BField} ${LIB_SRC_Plugins})
@@ -51,11 +51,22 @@ target_include_directories(Actscore
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
   )
 
+# add performance testing support library
+add_library(PerfTesting STATIC "${PROJECT_SOURCE_DIR}/performance_testing")
+target_include_directories(PerfTesting
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/performance_testing>
+  $<INSTALL_INTERFACE:performance_testing>
+  PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  )
+set_target_properties(PerfTesting PROPERTIES LINKER_LANGUAGE CXX)
+
 add_subdirectory(exe_cuda)
 add_subdirectory(exe_gcc)
 
 # install-tree
-set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../include")
+set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../include" "\${CMAKE_CURRENT_LIST_DIR}/../performance_testing")
 configure_file(cmake/ActscoreConfig.cmake.in         ${PROJECT_BINARY_DIR}/cmake_install/ActscoreConfig.cmake @ONLY)
 configure_file(cmake/ActscoreConfigVersion.cmake.in  ${PROJECT_BINARY_DIR}/cmake_install/ActscoreConfigVersion.cmake @ONLY)
 install(FILES
@@ -72,14 +83,26 @@ install(TARGETS Actscore
   RESOURCE      DESTINATION resource COMPONENT runtime
   )
 
+install(TARGETS PerfTesting
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME       DESTINATION bin      COMPONENT runtime
+  LIBRARY       DESTINATION bin      COMPONENT runtime 
+  ARCHIVE       DESTINATION bin      COMPONENT devel
+  PUBLIC_HEADER DESTINATION include  COMPONENT devel
+  RESOURCE      DESTINATION resource COMPONENT runtime
+  )
+
 install(EXPORT ${PROJECT_NAME}Targets
   DESTINATION cmake
   )
 
+execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/performance_testing/scripts
+                                                           ${CMAKE_SOURCE_DIR}/INSTALL/scripts)
+
 install(CODE "MESSAGE(\"project is installed in ${CMAKE_INSTALL_PREFIX} .\")")
 
 # build-tree
-set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR})
+set(CONF_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/performance_testing)
 configure_file(cmake/ActscoreConfig.cmake.in          ${PROJECT_BINARY_DIR}/cmake/ActscoreConfig.cmake @ONLY)
 configure_file(cmake/ActscoreConfigVersion.cmake.in   ${PROJECT_BINARY_DIR}/cmake/ActscoreConfigVersion.cmake @ONLY)
 

--- a/exe_cuda/CMakeLists.txt
+++ b/exe_cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(KalmanFitterCudaTest KalmanFitterCudaTest.cu)
-target_link_libraries(KalmanFitterCudaTest Actscore )
+target_link_libraries(KalmanFitterCudaTest Actscore PerfTesting)
 
 install(TARGETS KalmanFitterCudaTest
   EXPORT ${PROJECT_NAME}Targets

--- a/exe_gcc/CMakeLists.txt
+++ b/exe_gcc/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(KalmanFitterGccTest KalmanFitterGccTest.cpp)
-target_link_libraries(KalmanFitterGccTest Actscore)
+target_link_libraries(KalmanFitterGccTest Actscore PerfTesting)
 
 install(TARGETS KalmanFitterGccTest
   EXPORT ${PROJECT_NAME}Targets

--- a/exe_gcc/KalmanFitterGccTest.cpp
+++ b/exe_gcc/KalmanFitterGccTest.cpp
@@ -11,6 +11,7 @@
 #include "Test/TestHelper.hpp"
 #include "Utilities/ParameterDefinitions.hpp"
 #include "Utilities/Units.hpp"
+#include "Utilities/Logger.hpp"
 
 #include <chrono>
 #include <cmath>
@@ -236,6 +237,7 @@ int main(int argc, char *argv[]) {
   KalmanFitterOptions<VoidOutlierFinder> kfOptions(gctx, mctx);
 
   std::vector<TrackState> fittedTracks(nSurfaces * nTracks);
+  int threads = 1;
 
   auto start_fit = std::chrono::high_resolution_clock::now();
   // #pragma omp parallel for
@@ -266,12 +268,17 @@ int main(int argc, char *argv[]) {
     if (not fitStatus) {
       std::cout << "fit failure for track " << it << std::endl;
     }
+     threads = omp_get_num_threads();
   }
 
   auto end_fit = std::chrono::high_resolution_clock::now();
   elapsed_seconds = end_fit - start_fit;
   std::cout << "Time (sec) to run KalmanFitter for " << nTracks << " : "
             << elapsed_seconds.count() << std::endl;
+
+  // Log execution time in csv file
+  Logger::logTime(Logger::buildFilename("nTracks", std::to_string(nTracks), "OMP_NumThreads", std::to_string(threads)), 
+	  elapsed_seconds.count()); 
 
   if (output) {
     std::cout << "writing KF results" << std::endl;

--- a/include/Utilities/CudaHelper.hpp
+++ b/include/Utilities/CudaHelper.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <vector>
+#include <string>
+#include <cstring>
+#include <cuda.h>
+
 #define GPUERRCHK(ans)                                                         \
   { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line,
@@ -11,3 +16,48 @@ inline void gpuAssert(cudaError_t code, const char *file, int line,
       exit(code);
   }
 }
+
+#define DELIMITER "*"
+
+// Convert GPU string configuration from gridSize and/or blockSize to cuda::dim3
+// 
+// Valid configurations: 
+// 	1. "<num_x>*<num_y>*<num_z>"  ->> use this for more clarity
+//	2. "<num_x>*<num_y>"
+//	3. "<num_x>"
+// OBS: when a dimenssion is missing, default value is 1.
+dim3 stringToDim3(char* config) {
+        const int defaultVal = 1;
+        char *token = std::strtok(config, DELIMITER);
+        std::vector<int> tokens;
+
+        while (token != NULL){
+                tokens.push_back(atoi(token));
+                token = std::strtok(NULL, DELIMITER);
+        }
+
+        for (int i = tokens.size(); i < 3; i++)
+                tokens.push_back(defaultVal);
+
+        return dim3(tokens[0], tokens[1], tokens[2]);
+}
+
+// Convert cuda::dim3 to string configurations for gridSize and/or blockSize
+std::string dim3ToString(dim3 size) {
+        std::string result;
+        result.append(std::to_string(size.x)).append(DELIMITER)
+              .append(std::to_string(size.y)).append(DELIMITER)
+              .append(std::to_string(size.z));
+        return result;
+}
+
+std::string filename(int nTracks, std::string gridSize, std::string blockSize) {
+        std::string filename;
+        filename.append( "nTracks_").append(std::to_string(nTracks))
+                .append("_gridSize_").append(gridSize)
+                .append("_blockSize_").append(blockSize)
+                .append(".csv");
+	return filename;
+}
+
+

--- a/performance_testing/Utilities/Logger.hpp
+++ b/performance_testing/Utilities/Logger.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// Utility functions to log execution time(s) in an output CSV file 
+namespace Acts {
+
+class Logger {
+
+public:
+	// Open/Create the filename with the given 'filename' and
+	// print the times separated by commas, on a single line
+	template<class... T>
+        static void logTime(std::string filename, const T&... times) {                
+
+		std::vector<double> timesVec = {times...}; 
+                std::ofstream myFile;
+                myFile.open (filename, std::ofstream::out | std::ofstream::app);
+
+                for (auto time : timesVec)
+                        myFile << time << ",";
+                myFile << std::endl;
+
+                myFile.close();
+       }
+
+	// Concatenate the given 'keywords' separated by '_'
+	// e.g. buildFilename("nTracks", "100") -> "nTracks_100";
+	// 	buildFilename("nTracks", "100", "1GeV", "CPU") -> "nTracks_100_1GeV_CPU";
+	template<typename... T>
+	static std::string buildFilename(const T&... keywords) {
+		std::vector<std::string> keysVec = {keywords...};
+		std::string filename("Results_");
+ 		auto appFn = [&filename] (std::string s) {filename.append(s).append("_");};
+
+		for (auto key : keysVec) {
+			appFn(key);		
+		}
+		
+		filename = filename.substr(0, filename.length() - 1).append(".csv");	
+		return filename;
+	}
+};
+
+} // end namespace Acts

--- a/performance_testing/scripts/statistical_run.sh
+++ b/performance_testing/scripts/statistical_run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "Input the path to executable file"
+  exit 1
+fi
+
+#The input parameter is the location of the executable
+echo "Start statistical runs for $1"
+
+pT=1.0
+nTracks=(10) #(100 1000 5000 10000 50000 100000) 
+gridSizes=('40')
+blockSizes=('8*8')
+
+# add variable B field 
+#-b "../../acts-data/MagneticField/ATLAS/ATLASBField_xyz.txt"
+
+for i in ${nTracks[@]}; do
+	for ((j=0; j<${#gridSizes[@]};++j)); do
+		for cnt in {1..2}; do
+                	echo "Run $cnt for ${i} tracks with gridSize=${gridSizes[j]} and blockSize=${blockSizes[j]}"
+                	./$1 -t ${i} -p ${pT} -d "gpu" -o 0 -g ${gridSizes[j]} -b ${blockSizes[j]}
+                	sleep 1;
+		done
+        done;
+done;
+
+


### PR DESCRIPTION
Added script for invoking the same executable several number of times; 
KalmanFitter GCC and CUDA versions now log the fitting time in a CSV file (which is easy loaded in Excel or Jupyter Notebooks for later statistics).