### PR TITLE
fix inverse matrix fn

### DIFF
--- a/include/Utilities/Math.hpp
+++ b/include/Utilities/Math.hpp
@@ -7,27 +7,31 @@
 // starting point code for matrix inversion:
 // https://gist.github.com/tgjones/06ddde4d9f7794d3883a
 
+// max size of the matrix required to inverse
+// the GPU needs a size known at compile time to allocate
+// space on the stack
+#define MAX 6
+
 namespace Acts {
 
 // forward definition
 template <typename T>
-ACTS_DEVICE_FUNC T determinant(T** m, int size);
+ACTS_DEVICE_FUNC T determinant(T* m, int size);
 
 template <typename T>
-ACTS_DEVICE_FUNC void submatrix(T** m, T** result, int size, int row, int col) {
+ACTS_DEVICE_FUNC void submatrix(T* m, T* result, int size, int row, int col) {
        int rowCnt = 0, colCnt = 0;
 
-        // TODO: optimize If-then-else for GPU
         if (size == 2) {
-                int idx = abs(size-row-1);
-                result[0][0] = m[idx][idx];
+                int idx = size*size-row*size-col-1;
+                *result = *(m+idx);
         } else {
                 for (int i = 0; i < size; i++) {
                         if (i != row) {
                                 colCnt = 0;
                                 for (int j = 0; j < size; j++) {
                                         if (j != col) {
-                                                result[rowCnt][colCnt] = m[i][j];
+                                                *(result+rowCnt*(size-1)+colCnt) = *(m+i*size+j);
                                                 colCnt++;
                                         }
                                 }
@@ -39,70 +43,64 @@ ACTS_DEVICE_FUNC void submatrix(T** m, T** result, int size, int row, int col) {
 }
 
 template <typename T>
-ACTS_DEVICE_FUNC T matMinor(T** m, int size, int row, int col) {
-        T** submat = (T**)malloc(sizeof(T)*(size-1));
-        for (int i = 0; i < size-1; i++)
-                submat[i] = (T*)malloc(sizeof(T)*(size-1));
+ACTS_DEVICE_FUNC T matMinor(T* m, int size, int row, int col) {
+ 
+//       T submat[(size-1)*(size-1)]  does not work on GPU;
+//       it only accepts const size allocations
+//       WORKAROUND: so allocate more than we actually use
 
-        submatrix(m, submat, size, row, col);
-        T det = determinant(submat, size-1);
-
-        for (int i = 0; i < size-1; i++)
-                free(submat[i]);
-        free(submat);
-        return det;
+	T submat[MAX*MAX];
+        submatrix(m, (T*)&submat, size, row, col);
+        return determinant((T*)&submat, size-1);
 }
 
 template <typename T>
-ACTS_DEVICE_FUNC T determinant(T** m, int size) {
+ACTS_DEVICE_FUNC T determinant(T* m, int size) {
         T det = 0.0;
 
-        // TODO optimize If-Then-Else for GPU
         if (size == 1) {
-                det = m[0][0];
+                det = *m;
         }
         else if (size == 2) {
-                det = m[0][0]*m[1][1] - m[0][1]*m[1][0];
+                det = (*m)*(*(m+size+1))-(*(m+1))*(*(m+size));
         }
         else {
                 for (int i = 0; i < size; i++) {
-                        double minor = matMinor(m, size, 0, i);
-                        double sign = (i % 2 == 1) ? -1.0 : 1.0;
-                        det += sign * m[0][i] * minor;
+                        T minor = matMinor(m, size, 0, i);
+                        T sign = (i % 2 == 1) ? -1.0 : 1.0;
+                        det += sign * (*(m+i)) * minor;
                 }
         }
         return det;
 }
 
 template <typename T>
-ACTS_DEVICE_FUNC void invert(const ActsMatrixX<T>* em, ActsMatrixX<T> *result) {
+ACTS_DEVICE_FUNC void invert(const ActsMatrixX<T>* em, ActsMatrixX<T>* result) {
         // make sure the matrix is square
         assert(em->rows() == em->cols());
-        int size = em->rows();
+        const int size = em->rows();
 
         // copy from eigen matrix (column major) to C array (row major)
-        T** m = (T**)malloc(sizeof(T)*size);
-        for (int i = 0; i < size; i++) {
-                m[i] = (T*)malloc(sizeof(T)*size);
+ 
+        // T m[size*size] does not work on GPU;
+        // it only accepts const size allocations
+        // WORKAROUND: so allocate more than we actually use
+	T m[MAX*MAX];
+        for (int i = 0; i < size; i++)
                 for (int j = 0; j < size; j++)
-                        m[i][j] = em->coeff(i,j);
-        }
+                        *(m+i*size+j)=em->coeff(i,j);
 
-        T det = determinant(m, size);
+        T det = determinant((T*)&m, size);
         T invDet = 1.0/det;
-//      std::cout << "det=" << det << " ,invDet= " << invDet << std::endl;
 
         for (int i = 0; i < size; i++)
                 for (int j = 0; j < size; j++) {
-                        T minor = matMinor(m, size, j, i);
+                        T minor = matMinor((T*)&m, size, j, i);
                         T sign = ((i + j) % 2 == 1) ? -1.0 : 1.0;
                         T cofactorM = minor * sign;
 
                         result->coeffRef(i,j) = invDet * cofactorM;
                 }
-        for (int i = 0; i < size; i++)
-                free(m[i]);
-        free(m);
 }
 
 template <typename T>


### PR DESCRIPTION
Performance improvements: 
- Use stack memory instead of heap
- Use matrix as vector for better data locality 
