### PR TITLE
calculate inverse with double precision regardless of the input data

### DIFF
--- a/include/Utilities/Math.hpp
+++ b/include/Utilities/Math.hpp
@@ -14,6 +14,9 @@
 
 namespace Acts {
 
+// the precision of the matrix inversion computations
+using T = double;
+
 // forward definition
 template <typename T> ACTS_DEVICE_FUNC T determinant(T *m, int size);
 
@@ -69,8 +72,10 @@ template <typename T> ACTS_DEVICE_FUNC T determinant(T *m, int size) {
   return det;
 }
 
-template <typename T>
-ACTS_DEVICE_FUNC void invert(const ActsMatrixX<T> *em, ActsMatrixX<T> *result) {
+// T is the data type of the computations (default is double)
+// P is the data type of the input/output matrices (aka ActsScalar)
+template <typename T, typename P>
+ACTS_DEVICE_FUNC void invert(const ActsMatrixX<P> *em, ActsMatrixX<P> *result) {
   // make sure the matrix is square
   assert(em->rows() == em->cols());
   const int size = em->rows();
@@ -83,26 +88,26 @@ ACTS_DEVICE_FUNC void invert(const ActsMatrixX<T> *em, ActsMatrixX<T> *result) {
   T m[MAX * MAX];
   for (int i = 0; i < size; i++)
     for (int j = 0; j < size; j++)
-      *(m + i * size + j) = em->coeff(i, j);
+      *(m + i * size + j) = static_cast<T>(em->coeff(i, j));
 
   T det = determinant((T *)&m, size);
   T invDet = 1.0 / det;
 
   for (int i = 0; i < size; i++)
     for (int j = 0; j < size; j++) {
-      T minor = matMinor((T *)&m, size, j, i);
+      T minor = matMinor(m, size, j, i);
       T sign = ((i + j) % 2 == 1) ? -1.0 : 1.0;
       T cofactorM = minor * sign;
 
-      result->coeffRef(i, j) = invDet * cofactorM;
+      result->coeffRef(i, j) = static_cast<P>(invDet * cofactorM); 
     }
 }
 
-template <typename T>
-ACTS_DEVICE_FUNC ActsMatrixX<T> calculateInverse(ActsMatrixX<T> m) {
+template <typename P>
+ACTS_DEVICE_FUNC ActsMatrixX<P> calculateInverse(ActsMatrixX<P> m) {
 #ifdef __CUDA_ARCH__
-  ActsMatrixX<T> result(m.rows(), m.cols());
-  invert(&m, &result);
+  ActsMatrixX<P> result(m.rows(), m.cols());
+  invert<T,P>(&m, &result);
   return result;
 #else
   return m.inverse();

--- a/include/Utilities/Math.hpp
+++ b/include/Utilities/Math.hpp
@@ -14,9 +14,6 @@
 
 namespace Acts {
 
-// the precision of the matrix inversion computations
-using T = double;
-
 // forward definition
 template <typename T> ACTS_DEVICE_FUNC T determinant(T *m, int size);
 
@@ -103,7 +100,7 @@ ACTS_DEVICE_FUNC void invert(const ActsMatrixX<P> *em, ActsMatrixX<P> *result) {
     }
 }
 
-template <typename P>
+template <typename P, typename T = double>
 ACTS_DEVICE_FUNC ActsMatrixX<P> calculateInverse(ActsMatrixX<P> m) {
 #ifdef __CUDA_ARCH__
   ActsMatrixX<P> result(m.rows(), m.cols());


### PR DESCRIPTION
The internal computations for matrix inverse are using double precision regardless of the precision of the input data type.